### PR TITLE
Add support for a default_input configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Next step: Check what happens if the AVR is reset or is temporary not available.
 # Configuration
 
 Example accessory config (needs to be added to the homebridge config.json):
+
  ```
 "accessories": [
 	{
@@ -23,7 +24,15 @@ Example accessory config (needs to be added to the homebridge config.json):
 		"name": "My Onkyo",
 		"ip_address": "10.0.1.23",
 		"model" : "TX-NR609",
-		"poll_status_interval": "900"
+		"poll_status_interval": "900",
+		"default_input": "sat"
 	}
 ]
  ```
+ 
+ `default_input` is optional. If it not supplied, the previous input will be persisted. If a valid option is supplied, a request to set the input to the specified source will be made when the unit is turned on. The valid options depend on the unit. As a rule of thumb try to use the values as they are printed on the remote. 
+ Examples of values:
+ - VCR
+ - SAT
+ - DVD
+ 

--- a/index.js
+++ b/index.js
@@ -103,12 +103,6 @@ eventSystemPower: function( response)
 	if (this.switchService ) {
 		this.switchService.getCharacteristic(Characteristic.On).setValue(this.state, null, "statuspoll");
 	}	
-
-	// If the AVR has just been turned on, apply the Input default
-	if (this.state && this.defaultInput) {
-		this.log("Attempting to set the input selector to sat");
-		this.eiscp.command("input-selector="+this.defaultInput);
-	}
 },
 
 eventVolume: function( response)
@@ -151,6 +145,13 @@ setPowerState: function(powerOn, callback, context) {
 				if (that.switchService ) {
 					that.switchService.getCharacteristic(Characteristic.On).setValue(powerOn, null, "statuspoll");
 				}					
+			}
+			else {
+				// If the AVR has just been turned on, apply the Input default
+				if (this.state && this.defaultInput) {
+					this.log("Attempting to set the input selector to sat");
+					this.eiscp.command("input-selector="+this.defaultInput);
+				}
 			}
 		}.bind(this) );
 	} else {

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function HttpStatusAccessory(log, config)
 	this.name = config["name"];
 	this.model = config["model"];
 	this.poll_status_interval = config["poll_status_interval"] || "0";
+	this.defaultInput = config["default_input"]; 
 		
 	this.state = false;
 	this.interval = parseInt( this.poll_status_interval);
@@ -42,7 +43,6 @@ function HttpStatusAccessory(log, config)
 	
 	this.eiscp.on('debug', this.eventDebug.bind(this));
 	this.eiscp.on('error', this.eventError.bind(this));
-	this.eiscp.on('connect', this.eventConnect.bind(this));
 	this.eiscp.on('connect', this.eventConnect.bind(this));
 	this.eiscp.on('system-power', this.eventSystemPower.bind(this));
 	this.eiscp.on('volume', this.eventVolume.bind(this));
@@ -103,6 +103,12 @@ eventSystemPower: function( response)
 	if (this.switchService ) {
 		this.switchService.getCharacteristic(Characteristic.On).setValue(this.state, null, "statuspoll");
 	}	
+
+	// If the AVR has just been turned on, apply the Input default
+	if (this.state && this.defaultInput) {
+		this.log("Attempting to set the input selector to sat");
+		this.eiscp.command("input-selector="+this.defaultInput);
+	}
 },
 
 eventVolume: function( response)

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ setPowerState: function(powerOn, callback, context) {
 				that.state = false;
 				that.log( "setPowerState - PWR OFF: ERROR - current state: %s", that.state);
 				if (that.switchService ) {
-					that.switchService.getCharacteristic(Characteristic.On).setValue(powerOn, null, "statuspoll");
+					that.switchService.getCharacteristic(Characteristic.On).setValue(that.state, null, "statuspoll");
 				}					
 			}			
 		}.bind(this) );		


### PR DESCRIPTION
As per the updated README:

`default_input` is optional. If it not supplied, the previous input will be persisted. If a valid option is supplied, a request to set the input to the specified source will be made when the unit is turned on. 

Note: I also removed a duplicate line.